### PR TITLE
Fix deprecation for String.strip

### DIFF
--- a/lib/tapex/diagnostic.ex
+++ b/lib/tapex/diagnostic.ex
@@ -44,7 +44,7 @@ defmodule Tapex.Diagnostic do
   # Prepends each line of a message with the diagnostic indicator
   defp diagnosticify(message) when is_binary(message) do
     String.split(message, "\n")
-    |> Enum.reject(&(String.strip(&1) == ""))
+    |> Enum.reject(&(String.trim(&1) == ""))
     |> Enum.map_join("\n", &("#     " <> &1))
   end
 end


### PR DESCRIPTION
Use String.trim instead.

This fixes a deprecation that I believe started on Elixir 1.3