### PR TITLE
properly format excluded tests

### DIFF
--- a/lib/tapex/line.ex
+++ b/lib/tapex/line.ex
@@ -57,6 +57,9 @@ defmodule Tapex.Line do
     "# " <> color_wrap("TODO", :blue, colorize) |> spacecat(message)
   end
 
+  defp get_directive(%{state: {:excluded, reason}}) when is_binary(reason) do
+    {:skip, reason}
+  end
   defp get_directive(%{tags: %{skip: true}}) do
     {:skip, nil}
   end
@@ -80,6 +83,7 @@ defmodule Tapex.Line do
     case state do
       nil -> true
       {:skip, _} -> true
+      {:excluded, _} -> true
       _ -> false
     end
   end

--- a/test/tapex/line_test.exs
+++ b/test/tapex/line_test.exs
@@ -36,6 +36,18 @@ defmodule Tapex.LineTest do
     assert result == "ok       5 is unspecific (ATest) # SKIP"
   end
 
+  test "format_line with exclude" do
+    test = %{
+      case: "ATest",
+      name: "is unspecific",
+      state: {:excluded, "due to integration filter"},
+      tags: %{}
+    }
+
+    result = format_line(test, 5, false)
+    assert result == "ok       5 is unspecific (ATest) # SKIP due to integration filter"
+  end
+
   test "format_line with todo and message" do
     test = %{
       state: nil,


### PR DESCRIPTION
This changes tests that are excluded to be something like:

    ok       5 is unspecific (ATest) # SKIP due to integration filter

Without this change, it is instead formatted as:

    not ok   5 is unspecific (ATest)